### PR TITLE
Add version stamping to the build process

### DIFF
--- a/CovidAPI/src/CovidAPI/CovidAPI.csproj
+++ b/CovidAPI/src/CovidAPI/CovidAPI.csproj
@@ -5,6 +5,7 @@
     <AWSProjectType>Lambda</AWSProjectType>
     <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <VersionPrefix>2.0.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="6.0.1" />

--- a/CovidAPI/src/CovidAPI/Startup.cs
+++ b/CovidAPI/src/CovidAPI/Startup.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Amazon.DynamoDBv2;
+using System.Reflection;
 
 namespace CovidAPI
 {
@@ -19,6 +20,11 @@ namespace CovidAPI
     {
         public Startup(IConfiguration configuration)
         {
+            var assembly = Assembly.GetExecutingAssembly();
+            var assemblyVersion = assembly.GetCustomAttributes<AssemblyInformationalVersionAttribute>().ToList()[0].InformationalVersion;
+
+            Console.WriteLine($"AssemblyInfo - name: {assembly.GetName().Name}, Version: {assemblyVersion}");
+
             Configuration = configuration;
         }
 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -42,6 +42,7 @@ phases:
         --s3-bucket $BUILD_OUTPUT_BUCKET
         --s3-prefix covid-safe/$CODEBUILD_BUILD_ID
         --output-template CovidAPIStack.yml
+        --msbuild-parameters "/p:VersionSuffix=${CODEBUILD_RESOLVED_SOURCE_VERSION:0:7}"
 
 artifacts:
   files:


### PR DESCRIPTION
Use the AssemblyInformationalVersion attribute to add a git sha1 to
the version.
Also make the version prefix 2.0.0