### PR TITLE
Add SNS Permissions to the pipeline role

### DIFF
--- a/CodePipeline.yml
+++ b/CodePipeline.yml
@@ -330,6 +330,9 @@ Resources:
                   - 'kms:ListKeys'
                   - 'kms:ListAliases'
                 Resource: '*'
+              - Effect: Allow
+                Action: sns:Publish
+                Resource: !Ref ProdApprovalGateTopic
       Tags:
         - Key: Project
           Value: !Ref ProjectName


### PR DESCRIPTION
In order for the Approval gate to be able to publish to the SNS topic created
for it, the pipeline role must have publish permissions