### PR TITLE
Use a codestar connection to connect to source repository

### DIFF
--- a/CodePipeline.yml
+++ b/CodePipeline.yml
@@ -18,6 +18,10 @@ Parameters:
   ProdAccountNo:
     Type: String
     Description: The Account Number of the prod account
+  SourceRepository:
+    Type: String
+    Default: scottjbaldwin/AWSCodePipelineExample
+    Description: The Account Number of the prod account
 
 Resources:
   ArtefactBucket:
@@ -339,8 +343,7 @@ Resources:
                 Resource: !Ref ProdApprovalGateTopic
               - Effect: Allow
                 Action:
-                  - 'codestar-connections:GetConnection'
-                  - 'codestar-connections:ListConnections'
+                  - 'codestar-connections:UseConnection'
                 Resource: !Ref GitHubConnection
       Tags:
         - Key: Project
@@ -409,8 +412,8 @@ Resources:
                     - Name: SourceArtefact
                   RunOrder: 1
                   Configuration:
-                    ConnectionArn: "arn:aws:codestar-connections:ap-southeast-2:442623963256:connection/3e22674d-2fc7-47da-9bda-8a20ebd55e50"
-                    FullRepositoryId: "napalicorp/AWSCodePipelineExample"
+                    ConnectionArn: !Ref GitHubConnection
+                    FullRepositoryId: !Ref SourceRepository
                     BranchName: "main"
                     OutputArtifactFormat: "CODE_ZIP"
             - Name: Build
@@ -562,3 +565,4 @@ Resources:
               "region": "$.region"
             InputTemplate: "{\"SNSTopic\": \"Pipeline <pipeline>, execution id <executionId> has failed! URL: https://ap-southeast-2.console.aws.amazon.com/codesuite/codepipeline/pipelines/<pipeline>/view?region=<region>\"}"
 
+            

--- a/CodePipeline.yml
+++ b/CodePipeline.yml
@@ -280,7 +280,11 @@ Resources:
               - !Sub 'arn:aws:s3:::${BucketPrefix}-artefactbucket'
             Action: 
               - 's3:*'
-
+  GitHubConnection:
+    Type: 'AWS::CodeStarConnections::Connection'
+    Properties:
+      ConnectionName: GitHubConnection
+      ProviderType: GitHub
   PipelineExecutionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -333,6 +337,11 @@ Resources:
               - Effect: Allow
                 Action: sns:Publish
                 Resource: !Ref ProdApprovalGateTopic
+              - Effect: Allow
+                Action:
+                  - 'codestar-connections:GetConnection'
+                  - 'codestar-connections:ListConnections'
+                Resource: !Ref GitHubConnection
       Tags:
         - Key: Project
           Value: !Ref ProjectName
@@ -389,20 +398,21 @@ Resources:
         Stages:
             - Name: Source
               Actions:
-                - Name: GitHubRepo
+                - Name: Source
+                  InputArtifacts: []
                   ActionTypeId:
-                    Category: Source
-                    Owner: ThirdParty
-                    Provider: GitHub
                     Version: '1'
-                  Configuration:
-                    Owner: scottjbaldwin
-                    Repo: AWSCodePipelineExample
-                    Branch: main
-                    OAuthToken:  "{{resolve:secretsmanager:CovidSafeOAuthToken:SecretString:AccessToken}}"
+                    Owner: AWS
+                    Category: Source
+                    Provider: CodeStarSourceConnection
                   OutputArtifacts:
                     - Name: SourceArtefact
                   RunOrder: 1
+                  Configuration:
+                    ConnectionArn: "arn:aws:codestar-connections:ap-southeast-2:442623963256:connection/3e22674d-2fc7-47da-9bda-8a20ebd55e50"
+                    FullRepositoryId: "napalicorp/AWSCodePipelineExample"
+                    BranchName: "main"
+                    OutputArtifactFormat: "CODE_ZIP"
             - Name: Build
               Actions:
                 - Name: CodeBuild

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ In order for this example to run, the infrastructure must be set up in the follo
 
 1. The Build Account base infrastructure must be provisioned by executing `BuildAccountBaseInfrastructure.yml` cloudformation script in the Build Account
 1. The dev and prod deployment roles need to be provisioned by executing the `CrossAccountCFNRole.yml` cloudformation script, and passing in the arn of the KMS key provisioned in the previous step
-1. The CodePipeline can then be provisioned using the `CodePipeline.yml` again passing in the arn of the KMS key to use for artefact encryption which was provisioned as part of the build account base infratructure
+1. The CodePipeline can then be provisioned using the `CodePipeline.yml` again passing in the arn of the KMS key to use for artefact encryption which was provisioned as part of the build account base infratructure. The CloudFormation also creates a CodeStar connection to GitHub. This connection, however, will be in pending state after the creation. You need to setup the connection as an onetime activity before it can be used in the pipeline.
 
 This project uses conventions based on ProjectName in order to minimize the number of parameters required to pass to the respective cloudformation templates. For example, the codepipeline assumes
 that there are roles named `${ProjectName}-${AWS::Region}-DeploymentRole` in both the prod and dev accounts, rather than passing explicit arns in. These roles are set up by the cloudformation scripts as described above.


### PR DESCRIPTION
The current implementation has the source repo hardcoded in the codepipeline, making it hard to trigger the pipeline from a different repo.  
This PR automatically provisions a codestar connection (in pending state) and uses it in the pipeline. Also, parameterises the CodePipeline.yaml CFN so that we can point the pipeline at a different repository (a folk).