### PR TITLE
Update the codebuild environment

### DIFF
--- a/CodePipeline.yml
+++ b/CodePipeline.yml
@@ -10,7 +10,7 @@ Parameters:
     Default: covid-safe
   CodeBuildEnvironment:
     Type: String
-    Default: "aws/codebuild/standard:5.0"
+    Default: "aws/codebuild/standard:6.0"
     Description: Name of the image to use for the CodeBuild container
   DevAccountNo:
     Type: String

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -2,7 +2,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      dotnet: 3.1
+      dotnet: 6
     commands:
       
       #Install Amazon Lambda Tools  


### PR DESCRIPTION
- Update the aws codebuild image
- Update the dotnet runtime version in the buildspec

NOTE: I have not upgraded the project to .net 6, but kept it at .net 3.1. This is to validate if this is a possible way forward.